### PR TITLE
Adaptation pour ETSMobile

### DIFF
--- a/etsmtl-signets-webservices/build.gradle
+++ b/etsmtl-signets-webservices/build.gradle
@@ -29,8 +29,8 @@ android {
     buildToolsVersion "23.0.3"
 
     defaultConfig {
-        minSdkVersion 19
-        targetSdkVersion 24
+        minSdkVersion 14
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }

--- a/etsmtl-signets-webservices/build.gradle
+++ b/etsmtl-signets-webservices/build.gradle
@@ -30,7 +30,7 @@ android {
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 21
         versionCode 1
         versionName "1.0"
     }
@@ -40,14 +40,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
-}
-
-dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:24.2.0'
-    compile 'joda-time:joda-time:2.9.4'
 
 }
 


### PR DESCRIPTION
Malgré le fait que la librairie ait été sortie en septembre dernier, on dirait qu'il ne peut être synchronisé à ETSMobile dû aux prérequis un peu trop élevé.

Je compte enlever les vieux modèles dans l'application en soi (qui remontent à 2014 et qui ne contient pas certains changements requis pour faire le dialog concernant les évaluations de cours) et utiliser la librairie à la place, ce qui va libérer un peu la maintenance niveau HTTP pour ETSMobile.

Dis-moi ce que t'en penses.